### PR TITLE
Fix date parsing

### DIFF
--- a/script.py
+++ b/script.py
@@ -9,7 +9,8 @@ from bokeh.plotting import figure
 
 df = pd.read_csv(r'~/Projects/Solving_Delhi_pollution/data/Delhi_AQIBulletins.csv')
 
-df['year'] = pd.to_datetime(df['date']).dt.year
+df['date'] = pd.to_datetime(df['date'])
+df['year'] = df['date'].dt.year
 
 print(df['Prominent Pollutant'][23])
 
@@ -28,7 +29,7 @@ date_range = RangeSlider(
 pollutant_select = Select(
 	title="Select Pollutant",
     value="All",
-	options=["All"] + list(set(df['Prominent Pollutant']))
+	options=["All"] + list(set(df['Prominent Pollutant'].dropna().astype(str)))
 	)
 
 # Figure


### PR DESCRIPTION
## This PR addresses one main issue and one potential future issue  

### Main Issue — Chart Not Rendering Correctly  
The `date` column was not properly parsed as `datetime`, causing the Bokeh chart to fail to display data points correctly.  

### Potential Future Issue — Incomplete Pollutant Options  
The pollutant selection dropdown may include `NaN` values or unformatted strings.

Fixes #1 